### PR TITLE
Update report.tex

### DIFF
--- a/scratch/report/report.tex
+++ b/scratch/report/report.tex
@@ -329,7 +329,7 @@
     \legend{Experimental,,Simulation,}
 \end{axis}
 \end{tikzpicture}
-\caption{Sn-1 chain order parameters.}\label{sn-2_Order_Parameters}
+\caption{Sn-2 chain order parameters.}\label{sn-2_Order_Parameters}
 \end{figure}
 
 


### PR DESCRIPTION
The label of the second carbon tail order parameter plot had a typo. Changed from sn-1 to sn-2.