### PR TITLE
The old version will be incorrect...

### DIFF
--- a/scratch/report/calc_FORM_FACTOR.sh
+++ b/scratch/report/calc_FORM_FACTOR.sh
@@ -26,7 +26,7 @@ echo $LIPIDname | gmx traj -f centered.xtc -s ../topol.tpr -com -ox com.xvg -xvg
 com=$(cat com.xvg | awk '{sum1=sum1+$4; sum=sum+1;}END{print sum1/sum}')
 cat electronDENSITY.xvg | awk -v com=$com '{print $1-com" "$2}' > electronDENSITYcent.xvg
 
-slice=$(cat electronDENSITY.xvg | awk '{if(NR==2) print $1}')
+slice=$(head -n2 electronDENSITY.xvg | awk '{dz=$1-prev;prev=$1}END{print dz}')
 bulkDENS=$(tail -n 1 electronDENSITY.xvg | awk '{print $2}')
 cat electronDENSITYcent.xvg | awk -v slice=$slice -v bulkDENS=$bulkDENS 'BEGIN{scale=0.01;}{for(q=0;q<1000;q=q+1){F[q]=F[q]+($2-bulkDENS)*cos(scale*q*$1)*slice;}}END{for(q=0;q<1000;q=q+1){print 0.1*q*scale" "0.01*sqrt(F[q]*F[q])
 }}' > ../Form_Factor_From_Simulation.dat


### PR DESCRIPTION
...if the first bin is not at zero.

The wrong slice size will mostly affect the heights of the lobes, not the zeros.