### PR TITLE
Form factor molecules with multiple g3s

### DIFF
--- a/scratch/scriptsbyhsantila/center_n_calcFF.sh
+++ b/scratch/scriptsbyhsantila/center_n_calcFF.sh
@@ -67,11 +67,24 @@ for mol in $(awk '{print $1}' ${molMappFile}); do
     mapName=$(grep ${mol} ${molMappFile} | awk '{printf "%s\n",$4}')
     cat ${mapName} >> foobar.map
 done
-G1CH3name=`grep M_G1C[0-9]*_M foobar.map | tail -n1 | awk '{print $2}'`
-echo 'The name of the CH3 carbon in sn-1 chain:' $G1CH3name
+G1CH3name=`grep M_[1-9]*G1C[0-9]*_M foobar.map | tail -n1 | awk '{print $2}'`
+if [ -z "$G1CH3name" ]
+then
+    echo 'NO ATOM found for centering. Do you have a glycerol backbone? Exiting.'
+    echo
+    exit
+else
+    echo 'The name of the CH3 carbon in sn-1 chain:' $G1CH3name
+fi
 #
 # Find the number of the CH3 atom in the last lipid:
 echo -e "a ${G1CH3name}\nq" | gmx make_ndx -f $tprFile -o foo.ndx >& make_ndx.output
+grep "${G1CH3name}" make_ndx.output | grep Found
+if [ `grep $G1CH3name make_ndx.output | grep Found | awk '{print $2}'` == 0 ]
+then
+    echo 'and hence can not center. Exiting.'
+    exit
+fi
 G1CH3number=`grep '[0-9]' foo.ndx | tail -n1 | awk '{print $NF}'`
 echo "The atom number of the last lipid's CH3: " $G1CH3number
 rm make_ndx.output


### PR DESCRIPTION
The current version of the script assumes that there is only one glycerol backbone in the lipid. This is, however, not the case e.g. for cardiolipin.

The assumption does not really matter if there are any lipids with just one glycerol backbone (PC, PG, PE, ...) in the bilayer. However, if the bilayer would be of pure cardiolipin, the centering script would not work. It would (unfortunately) not crash, but instead of at step 2/3 centering around one of the tail methyl groups, it would center around whatever atom happens to be last in the concatenated mapping files. Typically this will be water or an ion, which will mess up the whole centering.

The fix: Script that finds also the glycerols of lipids that have multiple glycerols.

### Demonstration
Run original:
```
localhost:POPCandCLinCHARMM36 bb$ pwd
MATCH/scratch/scriptsbyhsantila/testSystems/POPCandCLinCHARMM36
localhost:POPCandCLinCHARMM36 bb$ ../../center_n_calcFF.sh mappingMolecules.txt PC_CL.tpr short.xtc out.xtc > example.orig
localhost:POPCandCLinCHARMM36 bb$ mv electronDENSITY_* Electron_Density_From_Simulation.dat Form_Factor_From_Simulation.dat orig/
```
Fix the code. Run the fixed code:
```
localhost:POPCandCLinCHARMM36 bb$ ../../center_n_calcFF.sh mappingMolecules.txt PC_CL.tpr short.xtc out.xtc > example.new
```
Compare:
```
localhost:POPCandCLinCHARMM36 bb$ diff -y example.orig example.new
Mapping: mappingMolecules.txt					Mapping: mappingMolecules.txt
TPR in:  PC_CL.tpr						TPR in:  PC_CL.tpr
XTC in:  short.xtc						XTC in:  short.xtc
XTC out: out.xtc						XTC out: out.xtc

Will now CENTER trajectory short.xtc to out.xtc.		Will now CENTER trajectory short.xtc to out.xtc.

Making molecules whole...					Making molecules whole...
Selected 0: 'System'						Selected 0: 'System'
Reading frame       0 time    0.000   				Reading frame       0 time    0.000   
Reading frame      20 time  400.000    ->  frame     20 time 	Reading frame      20 time  400.000    ->  frame     20 time 

The name of the CH3 carbon in sn-1 chain: C316		      |	The name of the CH3 carbon in sn-1 chain: CD18
The atom number of the last lipid's CH3:  22917		      |	Found 60 atoms with name CD18
Centering molecules around atom 22917...		      |	The atom number of the last lipid's CH3:  14877
							      >	Centering molecules around atom 14877...
Selected 7: 'centralAtom'					Selected 7: 'centralAtom'
Selected 0: 'System'						Selected 0: 'System'

The name of the g3 carbon(s) in POPC: C1			The name of the g3 carbon(s) in POPC: C1
No g3 carbons in TIP3.						No g3 carbons in TIP3.
The name of the g3 carbon(s) in TOCL2: C31 C11			The name of the g3 carbon(s) in TOCL2: C31 C11
No g3 carbons in SOD.						No g3 carbons in SOD.
Centering around the center of mass of index group g3carbons.	Centering around the center of mass of index group g3carbons.
Selected 8: 'g3carbons'						Selected 8: 'g3carbons'
Selected 0: 'System'						Selected 0: 'System'
Centering done							Centering done

Calculating density profiles...					Calculating density profiles...
rm: electronDENSITY.xvg: No such file or directory		rm: electronDENSITY.xvg: No such file or directory
- POPC -							- POPC -
The groups selected for centering and for density calculation	The groups selected for centering and for density calculation
Selected 8: 'g3carbons'						Selected 8: 'g3carbons'
Selected 3: 'POPC'						Selected 3: 'POPC'
- TIP3 -							- TIP3 -
The groups selected for centering and for density calculation	The groups selected for centering and for density calculation
Selected 8: 'g3carbons'						Selected 8: 'g3carbons'
Selected 4: 'TIP3'						Selected 4: 'TIP3'
- TOCL2 -							- TOCL2 -
The groups selected for centering and for density calculation	The groups selected for centering and for density calculation
Selected 8: 'g3carbons'						Selected 8: 'g3carbons'
Selected 2: 'TOCL2'						Selected 2: 'TOCL2'
- SOD -								- SOD -
The groups selected for centering and for density calculation	The groups selected for centering and for density calculation
Selected 8: 'g3carbons'						Selected 8: 'g3carbons'
Selected 5: 'SOD'						Selected 5: 'SOD'

Calculating form factor...					Calculating form factor...
```
which shows that the fixed code picks a cardiolipin tail CH3-carbon instead of a POPC one (because TOCL2 was later in the mapping file than POPC). Despite of this, however, the outcome is practically unchanged:
```
localhost:POPCandCLinCHARMM36 bb$ diff -y Electron_Density_From_Simulation.dat orig/Electron_Density_From_Simulation.dat 
-4.83052 332.512					      |	-4.83052 332.572
-4.73294 333.048					      |	-4.73294 333.589
-4.63535 334.243					      |	-4.63535 333.87
-4.53776 336.833					      |	-4.53776 336.888
-4.44018 328.903					      |	-4.44018 328.558
-4.34259 336.066					      |	-4.34259 336.085
-4.245 330.614						      |	-4.245 330.606
-4.14742 330.338						-4.14742 330.338
-4.04983 336.243						-4.04983 336.243
-3.95225 338.895						-3.95225 338.895
-3.85466 329.449						-3.85466 329.449
-3.75707 335.38							-3.75707 335.38
-3.65949 331.155						-3.65949 331.155
-3.5619 334.161							-3.5619 334.161
-3.46431 335.615						-3.46431 335.615
-3.36673 332.081						-3.36673 332.081
-3.26914 339.493						-3.26914 339.493
-3.17156 330.528						-3.17156 330.528
-3.07397 338.508						-3.07397 338.508
-2.97638 332.858						-2.97638 332.858
-2.8788 342.877							-2.8788 342.877
-2.78121 328.104						-2.78121 328.104
-2.68362 341.612						-2.68362 341.612
-2.58604 338.192						-2.58604 338.192
-2.48845 343.826						-2.48845 343.826
-2.39086 362.054						-2.39086 362.054
-2.29328 374.543						-2.29328 374.543
-2.19569 397.457						-2.19569 397.457
-2.09811 408.644						-2.09811 408.644
-2.00052 424.784						-2.00052 424.784
-1.90293 438.17							-1.90293 438.17
-1.80535 437.594						-1.80535 437.594
-1.70776 414.09							-1.70776 414.09
-1.61017 394.431						-1.61017 394.431
-1.51259 373.694						-1.51259 373.694
-1.415 367.882							-1.415 367.882
-1.31742 334.386						-1.31742 334.386
-1.21983 317.558						-1.21983 317.558
-1.12224 298.215						-1.12224 298.215
-1.02466 296.789						-1.02466 296.789
-0.92707 298.71							-0.92707 298.71
-0.829484 292.211						-0.829484 292.211
-0.731897 284.951						-0.731897 284.951
-0.634311 280.959						-0.634311 280.959
-0.536725 279.339						-0.536725 279.339
-0.439138 270.505						-0.439138 270.505
-0.341552 269.084						-0.341552 269.084
-0.243966 260.619						-0.243966 260.619
-0.146379 243.195						-0.146379 243.195
-0.0487932 239.063						-0.0487932 239.063
0.0487932 245.703						0.0487932 245.703
0.146379 247.281						0.146379 247.281
0.243966 257.247						0.243966 257.247
0.341552 266.326						0.341552 266.326
0.439138 271.221						0.439138 271.221
0.536725 278.282						0.536725 278.282
0.634311 280.592						0.634311 280.592
0.731897 285.462						0.731897 285.462
0.829484 288.659						0.829484 288.659
0.92707 294.173							0.92707 294.173
1.02466 296.432							1.02466 296.432
1.12224 301.142							1.12224 301.142
1.21983 316.227							1.21983 316.227
1.31742 333.512							1.31742 333.512
1.415 353.551							1.415 353.551
1.51259 374							1.51259 374
1.61017 399.049							1.61017 399.049
1.70776 417.066							1.70776 417.066
1.80535 419.784							1.80535 419.784
1.90293 427.303							1.90293 427.303
2.00052 433.435							2.00052 433.435
2.09811 416.655							2.09811 416.655
2.19569 397.145							2.19569 397.145
2.29328 372.059							2.29328 372.059
2.39086 359.243							2.39086 359.243
2.48845 349.469							2.48845 349.469
2.58604 339.184							2.58604 339.184
2.68362 337.726							2.68362 337.726
2.78121 339.332							2.78121 339.332
2.8788 336.876							2.8788 336.876
2.97638 334.992							2.97638 334.992
3.07397 342.264							3.07397 342.264
3.17156 329.611							3.17156 329.611
3.26914 335.722							3.26914 335.722
3.36673 339.39							3.36673 339.39
3.46431 330.431							3.46431 330.431
3.5619 333.332							3.5619 333.332
3.65949 341.737							3.65949 341.737
3.75707 330.428							3.75707 330.428
3.85466 334.608							3.85466 334.608
3.95225 330.1							3.95225 330.1
4.04983 334.676						      |	4.04983 334.684
4.14742 332.439						      |	4.14742 332.749
4.245 335.258						      |	4.245 335.128
4.34259 335.348						      |	4.34259 334.928
4.44018 332.334						      |	4.44018 332.533
4.53776 331.35						      |	4.53776 331.555
4.63535 337.458						      |	4.63535 337.187
4.73294 331.405						      |	4.73294 331.788
4.83052 332.211						      |	4.83052 331.976
localhost:POPCandCLinCHARMM36 bb$
```